### PR TITLE
[Issue 42] Add firefox css to fix hidden control bar

### DIFF
--- a/src/style/custom.css
+++ b/src/style/custom.css
@@ -121,3 +121,10 @@ Quality selector CSS
     visibility: visible;
     opacity: 1
 }
+
+/*Firefox fix to control-bar which would dissapear depending on the aspect-ratio */
+@-moz-document url-prefix() {
+    .vjs-tech {
+      max-height: calc(100vh - 16rem);
+    }
+  }


### PR DESCRIPTION
Fixes https://github.com/besuper/TwitchNoSub/issues/42.

I've tested with Chrome and Firefox and the CSS is correctly only applying to Firefox. 

Without the fix:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/8181056/200281886-baa42477-60f4-4e61-a7fb-d9d3e529395f.png">

And with the fix
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/8181056/200281738-4f555188-25d7-4204-8019-df34781c3516.png">

I'll gladly discuss if this is the better approach and I'm open to ideas. Hope you'll consider it :-) 
