### PR TITLE
Fix #173 & #171

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,13 +12,12 @@ const oldWorker = window.Worker;
 window.Worker = class Worker extends oldWorker {
     constructor(twitchBlobUrl) {
         var workerString = getWasmWorkerJs(`${twitchBlobUrl.replaceAll("'", "%27")}`);
-        var workerUrl = workerString.replace("importScripts('", "").replace("')", "");
 
         const blobUrl = URL.createObjectURL(new Blob([`
             importScripts(
                 'https://cdn.jsdelivr.net/gh/besuper/TwitchNoSub/src/patch_amazonworker.js',
-                '${workerUrl}'
             );
+            ${workerString}
         `]));
 
         super(blobUrl);

--- a/userscript/twitchnosub.user.js
+++ b/userscript/twitchnosub.user.js
@@ -30,13 +30,12 @@
     window.Worker = class Worker extends oldWorker {
         constructor(twitchBlobUrl) {
             var workerString = getWasmWorkerJs(`${twitchBlobUrl.replaceAll("'", "%27")}`);
-            var workerUrl = workerString.replace("importScripts('", "").replace("')", "");
 
             const blobUrl = URL.createObjectURL(new Blob([`
                 importScripts(
                     'https://cdn.jsdelivr.net/gh/besuper/TwitchNoSub/src/patch_amazonworker.js',
-                    '${workerUrl}'
                 );
+                ${workerString}
             `]));
             super(blobUrl);
         }


### PR DESCRIPTION
This PR fixes issues #173 and #171.

The issue is that the current code assumes a non-modified worker coming from `getWasmWorkerJs()`. However, many Twitch third-party extensions inject their own modified worker. This is, for example, the case for my Twitch adblock extension TTV LOL PRO.

![The errors responsible for infinite loading](https://github.com/user-attachments/assets/25559724-c6a0-47d7-8048-e8e632a7091c)

The fix is to put the worker code as-is after this extension's `importScripts()` call (there can be multiple `importScripts` in a worker).

Tested with clean Twitch worker and one injected by TTV LOL PRO -- both work fine. Feel free to do more tests as I am not familiar with the inner workings of this extension.