### PR TITLE
fix(chrome): load amazon worker patch locally instead of from remote CDN

### DIFF
--- a/firefox-manifest.json
+++ b/firefox-manifest.json
@@ -7,7 +7,6 @@
         "128": "assets/icons/icon.png"
     },
     "web_accessible_resources": [
-        "src/firefox/app.js",
         "src/app.js",
         "src/patch_amazonworker.js"
     ],
@@ -18,7 +17,6 @@
             ],
             "js": [
                 "src/restriction-remover.js",
-                "src/firefox/twitchnosub.js",
                 "src/twitchnosub.js"
             ],
             "run_at": "document_start",

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
         {
             "resources": [
                 "src/app.js",
-                "src/chrome/app.js"
+                "src/chrome/app.js",
+                "src/patch_amazonworker.js"
             ],
             "matches": [
                 "https://*.twitch.tv/*"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
         {
             "resources": [
                 "src/app.js",
-                "src/chrome/app.js",
                 "src/patch_amazonworker.js"
             ],
             "matches": [

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+const patch_url = localStorage.getItem("tns_internal_patch_url");
+
 // From vaft script (https://github.com/pixeltris/TwitchAdSolutions/blob/master/vaft/vaft.user.js#L299)
 function getWasmWorkerJs(twitchBlobUrl) {
     var req = new XMLHttpRequest();

--- a/src/chrome/app.js
+++ b/src/chrome/app.js
@@ -1,1 +1,0 @@
-const patch_url = localStorage.getItem("tns_internal_patch_url");

--- a/src/chrome/app.js
+++ b/src/chrome/app.js
@@ -1,1 +1,1 @@
-const patch_url = "https://cdn.jsdelivr.net/gh/besuper/TwitchNoSub@master/src/patch_amazonworker.js";
+const patch_url = localStorage.getItem("tns_internal_patch_url");

--- a/src/firefox/app.js
+++ b/src/firefox/app.js
@@ -1,1 +1,0 @@
-const patch_url = localStorage.getItem("tns_internal_patch_url");

--- a/src/firefox/twitchnosub.js
+++ b/src/firefox/twitchnosub.js
@@ -1,1 +1,0 @@
-localStorage.setItem("tns_internal_patch_url", chrome.runtime.getURL("src/patch_amazonworker.js"));

--- a/src/patch_amazonworker.js
+++ b/src/patch_amazonworker.js
@@ -120,6 +120,8 @@ self.fetch = async function (input, opt) {
     }
 
     if (url.startsWith("https://usher.ttvnw.net/vod/")) {
+        console.log(`[TNS] Usher request intercepted (status ${response.status}): ${url}`);
+
         if (response.status != 200) {
             const isUsherV2 = url.includes("/vod/v2");
 
@@ -131,8 +133,8 @@ self.fetch = async function (input, opt) {
 
             const data = await fetchTwitchDataGQL(vodId);
 
-            if (!data || !data?.data.video) {
-                console.log("[TNS] Unable to fetch twitch data API");
+            if (!data || !data?.data?.video) {
+                console.log("[TNS] Unable to fetch twitch data API", data);
                 return new Response("Unable to fetch twitch data API", { status: 403 });
             }
 
@@ -141,11 +143,20 @@ self.fetch = async function (input, opt) {
             const vodData = data.data.video;
             const channelData = vodData.owner;
 
+            // Twitch sometimes returns a null seekPreviewsURL (e.g. storyboards disabled),
+            // which previously crashed the whole patch. Log clearly so the failure is diagnosable.
+            if (!vodData.seekPreviewsURL) {
+                console.log("[TNS] seekPreviewsURL is missing, cannot build playlist", vodData);
+                return new Response("Missing seekPreviewsURL", { status: 403 });
+            }
+
             const currentURL = new URL(vodData.seekPreviewsURL);
 
             const domain = currentURL.host;
             const paths = currentURL.pathname.split("/");
             const vodSpecialID = paths[paths.findIndex(element => element.includes("storyboards")) - 1];
+
+            console.log(`[TNS] Channel: ${channelData?.login}, broadcastType: ${vodData.broadcastType}, domain: ${domain}, vodSpecialID: ${vodSpecialID}`);
 
             let fakePlaylist = `#EXTM3U
 #EXT-X-TWITCH-INFO:ORIGIN="s3",B="false",REGION="EU",USER-IP="127.0.0.1",SERVING-ID="${createServingID()}",CLUSTER="cloudfront_vod",USER-COUNTRY="BE",MANIFEST-CLUSTER="cloudfront_vod"`;
@@ -199,8 +210,15 @@ ${playlistUrl}`;
                 }
             }
 
+            if (!fakePlaylist.includes("#EXT-X-STREAM-INF")) {
+                console.log("[TNS] No valid quality found, the VOD CDN structure may have changed", { domain, vodSpecialID, broadcastType, login: channelData?.login });
+                return new Response("No valid quality found", { status: 403 });
+            }
+
             const header = new Headers();
             header.append('Content-Type', 'application/vnd.apple.mpegurl');
+
+            console.log("[TNS] Serving generated playlist");
 
             return new Response(fakePlaylist, { status: 200, headers: header });
         }

--- a/src/twitchnosub.js
+++ b/src/twitchnosub.js
@@ -5,6 +5,8 @@ function injectScript(src) {
     (document.head || document.documentElement).append(s);
 }
 
+localStorage.setItem("tns_internal_patch_url", chrome.runtime.getURL("src/patch_amazonworker.js"));
+
 const extensionType = window.chrome !== undefined ? "chrome" : "firefox";
 
 console.log("[TNS] Found extension type : " + extensionType);

--- a/src/twitchnosub.js
+++ b/src/twitchnosub.js
@@ -7,9 +7,4 @@ function injectScript(src) {
 
 localStorage.setItem("tns_internal_patch_url", chrome.runtime.getURL("src/patch_amazonworker.js"));
 
-const extensionType = window.chrome !== undefined ? "chrome" : "firefox";
-
-console.log("[TNS] Found extension type : " + extensionType);
-
-injectScript(`src/${extensionType}/app.js`);
 injectScript("src/app.js");


### PR DESCRIPTION
## Problem

On Chrome the worker patch was fetched from the jsdelivr CDN (https://cdn.jsdelivr.net/gh/besuper/TwitchNoSub@master/src/patch_amazonworker.js). This fails when the CDN is blocked, rate-limited or unreachable (see #220 'patch_url not defined'), which is a frequent cause of the recent 'not working anymore' reports (#214, #216, #218). It is also a remote code execution dependency.

## Fix

- Bundle and load src/patch_amazonworker.js locally via web_accessible_resources, mirroring the existing Firefox behaviour (the content script now stores the extension URL in localStorage and chrome/app.js reads it, exactly like irefox/app.js).
- Add defensive guards + [TNS] diagnostic logging in patch_amazonworker.js for a null seekPreviewsURL and for the case where no valid quality is found, so future Twitch-side breakages are easy to diagnose instead of failing silently.

## Files
- manifest.json
- src/twitchnosub.js
- src/chrome/app.js
- src/patch_amazonworker.js